### PR TITLE
Fix for issue #12 - Unnamed element throws exception

### DIFF
--- a/src/form2object.js
+++ b/src/form2object.js
@@ -90,6 +90,8 @@
 			if (skipEmpty && value === '') continue;
 
 			name = nameValues[i].name;
+			if (typeof name === 'undefined') continue;
+
 			_nameParts = name.split(delimiter);
 			nameParts = [];
 			currResult = result;


### PR DESCRIPTION
Ignore form elements without name attributes. Elements without names were causing an exception to be thrown during processing.
