### PR TITLE
Fix checkbox boolean return breaking radio button value.

### DIFF
--- a/src/form2js.js
+++ b/src/form2js.js
@@ -273,6 +273,8 @@ var form2js = (function()
 			case 'TEXTAREA':
 				switch (fieldNode.type.toLowerCase()) {
 					case 'radio':
+						if (fieldNode.checked) return fieldNode.value;
+						break;
 					case 'checkbox':
                         if (fieldNode.checked && fieldNode.value === "true") return true;
                         if (!fieldNode.checked && fieldNode.value === "true") return false;


### PR DESCRIPTION
Maxim's commit #985a3f3214 Returning boolean values from checkboxes was
breaking radio buttons serialization/deserialization when value="true"
(string). This fixes that regression.
