### PR TITLE
Form fields named 'name' or 'id' break the form traversal.

### DIFF
--- a/src/js2form.js
+++ b/src/js2form.js
@@ -119,11 +119,11 @@ var js2form = (function()
 		{
 			name = '';
 
-			if (currNode.name && currNode.name != '')
+			if (currNode.name && typeof(currNode.name) === "string" && currNode.name != '')
 			{
 				name = currNode.name;
 			}
-			else if (useIdIfEmptyName && currNode.id && currNode.id != '')
+			else if (useIdIfEmptyName && currNode.id && typeof(currNode.id) === "string" && currNode.id != '')
 			{
 				name = currNode.id;
 			}


### PR DESCRIPTION
This commit ensures that the property being checked is a string, rather than  an object.

See this jsfiddle for demonstration of the problem:
http://jsfiddle.net/KJyCq/

And this jsfiddle (identical except using my modified version), showing it working:
http://jsfiddle.net/KJyCq/1/
