### PR TITLE
Fix for IE bug showing "null" string in input fields.

### DIFF
--- a/src/js2form.js
+++ b/src/js2form.js
@@ -84,7 +84,7 @@ var js2form = (function()
 		}
 		else if (_inputOrTextareaRegexp.test(field.nodeName))
 		{
-			field.value = value;
+			field.value = value || '';
 		}
 		else if (/SELECT/i.test(field.nodeName))
 		{


### PR DESCRIPTION
Must resort to empty string in IE otherwise "null" shows up.  Refer to
http://stackoverflow.com/questions/5387038/null-values-shown-in-form-fie
lds-in-ie
