### PR TITLE
Fix "form2js" reference.  Add js2form rootNode id support.  Add ASP.NET MVC select support.

### DIFF
--- a/src/js2form.js
+++ b/src/js2form.js
@@ -34,7 +34,7 @@
 	else
 	{
 		// Browser globals
-		root.form2js = factory();
+		root.js2form = factory();
 	}
 }(this, function ()
 {
@@ -61,6 +61,8 @@
 		if (arguments.length < 4) nodeCallback = null;
 		if (arguments.length < 5) useIdIfEmptyName = false;
 
+		rootNode = (typeof rootNode == 'string') ? document.getElementById(rootNode) : rootNode;
+		
 		var fieldValues,
 				formFieldsByName;
 
@@ -79,6 +81,9 @@
 			else if (typeof formFieldsByName[fieldName.replace(_arrayItemRegexp, '[]')] != 'undefined')
 			{
 				setValue(formFieldsByName[fieldName.replace(_arrayItemRegexp, '[]')], fieldValue);
+			}
+			else if (typeof formFieldsByName[fieldName.replace(_arrayItemRegexp, "")] != 'undefined') {
+				setValue(formFieldsByName[fieldName.replace(_arrayItemRegexp, "")], fieldValue);
 			}
 		}
 	}


### PR DESCRIPTION
Fix typo: "form2js" should be "js2form".
Add support for passing rootNode by id like form2js does.
Add SELECT list name convention used by ASP.NET MVC.