### PR TITLE
Serialize checked radio with value==="false" to boolean false

### DIFF
--- a/src/form2js.js
+++ b/src/form2js.js
@@ -285,10 +285,11 @@
 			case 'TEXTAREA':
 				switch (fieldNode.type.toLowerCase()) {
 					case 'radio':
+			if (fieldNode.checked && fieldNode.value === "false") return false;
 					case 'checkbox':
                         if (fieldNode.checked && fieldNode.value === "true") return true;
                         if (!fieldNode.checked && fieldNode.value === "true") return false;
-						if (fieldNode.checked) return fieldNode.value;
+			if (fieldNode.checked) return fieldNode.value;
 						break;
 
 					case 'button':


### PR DESCRIPTION
Makes the following HTML to be serialized as `{fixed: false}`:

``` html
  <input type="radio" value="true"  name="fixed" /> Fixed
  <input type="radio" value="false" name="fixed" checked="checked"/> Variable
```

Without this commit `form2js` would serialize the frist to `{fixed: true}` and the latter to `{fixed: "false"}` causing confusion with tests:

``` js
var obj = form2js(form);
if (obj.fixed) {
   console.log("This string will be logged to console.. no matter what");
}
```
