### PR TITLE
Fix bug

### DIFF
--- a/src/form2js.js
+++ b/src/form2js.js
@@ -196,7 +196,7 @@
 					{
 						if (!arrays[arrNameFull][arrIdx])
 						{
-							if ((/^[a-z_]+\[?/i).test(nameParts[j+1])) currResult[arrName].push({});
+							if ((/^[0-9a-z_]+\[?/i).test(nameParts[j+1])) currResult[arrName].push({});
 							else currResult[arrName].push([]);
 
 							arrays[arrNameFull][arrIdx] = currResult[arrName][currResult[arrName].length - 1];


### PR DESCRIPTION
If you have this in a form:
<input type="text" name="section[0].QYPS9YKL.es" value="Competición">
<input type="text" name="section[1].UVTGs8b4.es" value="Una Cierta Mirada">
<input type="text" name="section[2].**4AmHTq8M**.es" value="Cinéfondation">
<input type="text" name="section[3].**8pSARdDq**.es" value="Cámara de Oro">

The last two "input" is not transformed correctly, producing the following output:

{"section":[ {"QYPS9YKL":{"es":"Competición"}}, {"UVTGs8b4":{"es":"Una Cierta Mirada"}}, **[]**, **[]** ]}

This is because the "name" attribute of the inputs that fail **begin with a number**.
