### PR TITLE
Don't return disabled fields regardless of skipEmpty behavior

### DIFF
--- a/src/form2js.js
+++ b/src/form2js.js
@@ -246,6 +246,8 @@
 	}
 
     function extractNodeValues(node, nodeCallback, useIdIfEmptyName) {
+        if (node.disabled) return [];
+
         var callbackResult, fieldValue, result, fieldName = getFieldName(node, useIdIfEmptyName);
 
         callbackResult = nodeCallback && nodeCallback(node);


### PR DESCRIPTION
Since browsers typically do not send disabled form elements on
form submit, it's probably improper behavior to include them when
constructing a structured object regardless of the value of skipEmpty.

Added a check for a node's disabled property that returns an empty
array, thus preventing it from being added to formValues.
