### PR TITLE
Fix browserify problem with jquery.toObject

### DIFF
--- a/src/jquery.toObject.js
+++ b/src/jquery.toObject.js
@@ -23,8 +23,9 @@
  * Date: 29.06.11
  * Time: 20:09
  */
-
-(function($){
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('jquery')) : typeof define === 'function' && define.amd ? define(['jquery'], factory) : global.parsley = factory(global.jQuery);
+})(this, function($){
 
 	/**
 	 * jQuery wrapper for form2object()
@@ -63,4 +64,4 @@
 		}
 	}
 
-})(jQuery);
+});


### PR DESCRIPTION
Without this modification, if i try to use a global jQuery package (called with `require('jquery')`, the function toObject does not exists.