### PR TITLE
[codex] Fix dependency security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4203,9 +4203,9 @@
       "license": "MIT"
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -9053,9 +9053,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/test/integration/dependency-security.test.ts
+++ b/test/integration/dependency-security.test.ts
@@ -70,6 +70,30 @@ function isVulnerableVersion(name: string, version: string): boolean {
     return compareSemver(version, "1.6.1") < 0;
   }
 
+  if (name === "vite") {
+    if (major === 6) {
+      return compareSemver(version, "6.4.2") < 0;
+    }
+
+    if (major === 7) {
+      return compareSemver(version, "7.3.2") < 0;
+    }
+
+    if (major === 8) {
+      return compareSemver(version, "8.0.5") < 0;
+    }
+
+    return false;
+  }
+
+  if (name === "defu") {
+    if (major === 6) {
+      return compareSemver(version, "6.1.5") < 0;
+    }
+
+    return false;
+  }
+
   if (name === "yaml" && major === 2) {
     return compareSemver(version, "2.8.3") < 0;
   }
@@ -81,7 +105,7 @@ describe("dependency security", () => {
   it("does not leave known vulnerable dependency versions in the lockfile", () => {
     const lockfile = readLockfile();
     const packages = lockfile.packages ?? {};
-    const vulnerablePackages = ["brace-expansion", "picomatch", "smol-toml", "yaml"];
+    const vulnerablePackages = ["brace-expansion", "defu", "picomatch", "smol-toml", "vite", "yaml"];
 
     for (const [packagePath, packageInfo] of Object.entries(packages)) {
       const packageName = packagePath.split("/").at(-1);


### PR DESCRIPTION
## Summary
- refresh the lockfile to pick up patched transitive `vite` and `defu` releases
- extend the dependency security regression test to flag vulnerable `vite` and `defu` versions in `package-lock.json`

## Why
GitHub reported 4 open Dependabot alerts on the default branch. The root cause was vulnerable transitive versions locked in `package-lock.json` without a regression test covering those packages.

## Impact
The default branch will resolve patched dependency versions once this lands, and the integration suite will fail if vulnerable `vite` or `defu` versions are reintroduced.

## Validation
- `npm run test:integration`
- `npm audit --json`
- `npm ls vite defu --all`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh `package-lock.json` to pick up patched `vite@7.3.2` and `defu@6.1.7`, clearing current Dependabot alerts. Extend the dependency security test to fail if vulnerable `vite` (6<6.4.2, 7<7.3.2, 8<8.0.5) or `defu` (6<6.1.5) versions are reintroduced.

<sup>Written for commit f11b9885666a008d04621a7021c860034fa4585d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

