### PR TITLE
Cache removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.14.0
-          cache: npm
 
       - name: Install
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: Install
         run: npm ci

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.14.0
-          cache: npm
 
       - name: Install
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           node-version: 22.14.0
           registry-url: https://registry.npmjs.org
-          cache: npm
 
       - name: Use npm 11
         run: npm install --global npm@11.6.2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `cache: npm` from GitHub Actions workflows (`ci.yml`, `pages.yml`, `release.yml`) to prevent stale dependencies and ensure clean, reproducible installs on every run. This makes builds more deterministic across Node 22.x and matrix jobs.

<sup>Written for commit 2dd228ee7b28a816456f042088e3eda5f437bd97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

